### PR TITLE
fix a bug in dual_mixed_norm

### DIFF
--- a/fista.py
+++ b/fista.py
@@ -74,11 +74,11 @@ def dual_mixed_norm(coefs, n_samples, n_kernels, norm_):
     -------
     float
     """
-    if norm == 'l11':
+    if norm_ == 'l11':
         res = norm(coefs, np.inf)
-    elif norm == 'l12':
+    elif norm_ == 'l12':
         res = mixed_norm(coefs, np.inf, 2, n_samples, n_kernels)
-    elif norm == 'l21':
+    elif norm_ == 'l21':
         res = mixed_norm(coefs, 2, np.inf, n_samples, n_kernels)
     else:
         res = norm(coefs, 2)


### PR DESCRIPTION
In the dual_mixed_norm method, we need to specify a type of norm_.  The default value is l22. However, when we do not want to use the default setting, the method will return l22 norm incorrectly.